### PR TITLE
Grunt related stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,12 @@
   "bugs": {
     "url": "https://github.com/aemkei/jsfuck/issues"
   },
+  "scripts": {
+    "start": "grunt default watch"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "~1.2.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-jshint": "~0.6.4"


### PR DESCRIPTION
I'm rarely feel happy when some project asks me to install something globally. Because it breaks the node's "every dependency is relative to the project" approach and brings closer the Python-like hell of global dependencies version mismatches.

Luckily, there's no need to install grunt globally as npm treats local dependencies' binaries as the first class citizen.

Changes:

- Install and run grunt locally (instead of manually installing in globally) with all the other dependencies.

The start command now would be `npm start`.

- Run default grunt task before watching. This way changes, that were made when grunt was not turned off, won't pass untested.