### PR TITLE
Fix '10' example in Basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following source will do an `alert(1)`:
     0           =>  +[]
     1           =>  +!+[]
     2           =>  !+[]+!+[]
-    10          =>  [+!+[]]+[+[]]
+    10          =>  +[[+!+[]]+[+[]]]
     Array       =>  []
     Number      =>  +[]
     String      =>  []+[]


### PR DESCRIPTION
The current `10` example actually produces the `"10"` (i.e. a string), instead of the number `10` as the previous three example do. I've wrapped the expression in an extra pair of brackets, and added a leading `+` to convert it for a number