### PR TITLE
Use more compatible version of CRLF fix

### DIFF
--- a/jsfuck.js
+++ b/jsfuck.js
@@ -249,9 +249,9 @@
     for (var i in SIMPLE) {
       r += i + "|";
     }
-    r+=".";
+    r+= "\n|\r|.";
 
-    input.replace(new RegExp(r, 'gs'), function(c) {
+    input.replace(new RegExp(r, 'g'), function(c) {
       var replacement = SIMPLE[c];
       if (replacement) {
         output.push("(" + replacement + "+[])");

--- a/jsfuck.js
+++ b/jsfuck.js
@@ -249,7 +249,7 @@
     for (var i in SIMPLE) {
       r += i + "|";
     }
-    r+= "\n|\r|.";
+    r+= "\n|\r|\u2028|\u2029|.";
 
     input.replace(new RegExp(r, 'g'), function(c) {
       var replacement = SIMPLE[c];

--- a/test/jsfuck_test.js
+++ b/test/jsfuck_test.js
@@ -45,6 +45,7 @@ createTest(';&');
 createTest('\n');
 createTest('\r');
 createTest('\r\n');
+createTest('\u2028\u2029');
 createTest('false');
 createTest('true');
 createTest('undefined');


### PR DESCRIPTION
The "s" flag is not widely supported yet. Use explicit handling for `\r\n` as a workaround.