### PR TITLE
Optimize wrapper

### DIFF
--- a/test/jsfuck_test.js
+++ b/test/jsfuck_test.js
@@ -63,6 +63,11 @@ createTest('NaNtrue');
 createTest('trueNaN');
 createTest('undefinedNaN');
 createTest('~\\"');
+createTest('t~');
+createTest('~t');
+createTest('[(~t~)]');
+createTest('~0123456789 abcdefghijklmnopqrstuvwxyz()+.~');
+createTest('~0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ()+.~');
 
 for(var i=MIN; i<MAX ;i++) {
 	createTest(String.fromCharCode(i));


### PR DESCRIPTION
Optimize wrapper based on https://github.com/aemkei/jsfuck/pull/107#issuecomment-684646669. 

Replace `\` in escape character with `t` (cheapest symbol outside of base 16 numbers) on compile stage. On runtime stage replace `t` back with `\` before passing the string into the `Function` constructor. To avoid using `replace(x,y)` function which requires 2 arguments use `split()` and `join()` functions.

The "cost" of additional characters is about ~100.

Without this optimization one unmapped caracter has encoded length of about 3600 characters. Every additional unmapped character adds 2000 to the total length. 

For example, the lenght of `~` is 3605, `~~` is 5600, and `~~~` is 7595.
       
The loader with replace has encoded length of about 5300 characters and every additional character adds 100 to the total length. 

In the same example the length of `~~` becomes 5371 and `~~~` -- 5463.
       
So, when we have more than one unmapped character we want to encode whole input except select characters (that have encoded length less than about 70) into an escape sequence.