### PR TITLE
Update jsfuck.js

### DIFF
--- a/jsfuck.js
+++ b/jsfuck.js
@@ -49,7 +49,7 @@
     'y':   '(NaN+[Infinity])[10]',
     'z':   '(+(35))["to"+String["name"]](36)',
 
-    'A':   '(+[]+Array)[10]',
+    'A':   '(NaN+[]["entries"]())[11]',
     'B':   '(+[]+Boolean)[10]',
     'C':   'Function("return escape")()(("")["italics"]())[2]',
     'D':   'Function("return escape")()([]["flat"])["slice"]("-1")',


### PR DESCRIPTION
Shorter version of letter `A`

Old version has 507 char after encoding (due to word 'constructor' (Array))

New version has 187 char after encoding ('constructor' was changed to 'entries')