### PR TITLE
Remove redundant code

### DIFF
--- a/jsfuck.js
+++ b/jsfuck.js
@@ -231,12 +231,8 @@
 
   function escapeSequence(c) {
     var cc = c.charCodeAt(0);
-    if (cc < 256) {
-      return '\\' + cc.toString(8);
-    } else {
-      var cc16 = cc.toString(16);
-      return '\\u' + ('0000' + cc16).substring(cc16.length);  
-    }
+    var cc16 = cc.toString(16);
+    return '\\u' + ('0000' + cc16).substring(cc16.length);  
   }
 
   function escapeSequenceForReplace(c) {


### PR DESCRIPTION
It seems to work well if we turn all unmappedCharacter to utf-16 code.