### PR TITLE
Fixed broken Hieroglyphy URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
   
   <h3>Alternatives</h3>
   <ul>
-    <li><a href="http://patriciopalladino.com/files/hieroglyphy/">Hieroglyphy</a> (8 chars, browser only)</li>
+    <li><a href="https://github.com/alcuadrado/hieroglyphy">Hieroglyphy</a> (8 chars, browser only)</li>
     <li><a href="http://utf-8.jp/public/jsfuck.html">utf-8.jp</a> (broken)</li>
     <li><a href="http://discogscounter.getfreehosting.co.uk/js-noalnum.php">JS-NoAlnum</a> (broken)</li>
   </ul>


### PR DESCRIPTION
As mentioned in #136 

> The site links to an alternative called Hieroglyphy, but the [link](https://patriciopalladino.com/files/hieroglyphy/) is broken and just delivers you to a github pages 404
>
> If you do a quick search the original creator's github repository for Hieroglyphy is available here: https://github.com/alcuadrado/hieroglyphy

This PR just replaces that URL with the functioning one.